### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alikemalocalan/greentunnel4jvm/security/code-scanning/2](https://github.com/alikemalocalan/greentunnel4jvm/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, it likely needs `contents: read` to check out the code and `contents: write` to publish the artifact. We will add these permissions to the root of the workflow to apply them to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
