### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,5 +1,7 @@
 name: Build Gradle
 on: [push]
+permissions:
+  contents: read
 jobs:
   gradle:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/alikemalocalan/greentunnel4jvm/security/code-scanning/1](https://github.com/alikemalocalan/greentunnel4jvm/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves checking out the repository and building the project, it does not require write permissions. The minimal required permission is `contents: read`. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
